### PR TITLE
Pass interface index to handler

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -5,17 +5,20 @@
 // Author: http://richard.warburton.it/
 //
 // Example of minimal DHCP server:
-package dhcp4_test
+package main
 
 import (
-	dhcp "github.com/krolaw/dhcp4"
+	"fmt"
 	"log"
 	"math/rand"
 	"net"
 	"time"
+
+	dhcp "github.com/krolaw/dhcp4"
 )
 
 type DHCPHandler struct {
+	ifindex       int           // Index of network interface to use
 	ip            net.IP        // Server IP to use
 	options       dhcp.Options  // Options to send to DHCP Clients
 	start         net.IP        // Start of IP range to distribute
@@ -29,14 +32,35 @@ type lease struct {
 	expiry time.Time // When the lease expires
 }
 
+// Find index of the network interface the given IP is associated with.
+func LookupInterfaceIndexForIP(ip net.IP) int {
+	is, err := net.Interfaces()
+	if err != nil {
+		panic(err)
+	}
+	for _, i := range is {
+		as, err := i.Addrs()
+		if err != nil {
+			panic(err)
+		}
+		for _, a := range as {
+			if a.(*net.IPNet).IP.String() == ip.String() {
+				return i.Index
+			}
+		}
+	}
+	panic(fmt.Sprintf("Cannot find network interface for %s", ip))
+}
+
 func SetupHandler() *DHCPHandler {
 	handler := &DHCPHandler{
-		ip:            net.IP{172, 30, 0, 1},
+		ip:            net.IP{172, 16, 205, 1},
 		leaseDuration: 2 * time.Hour,
-		start:         net.IP{172, 30, 0, 2},
+		start:         net.IP{172, 16, 205, 2},
 		leaseRange:    50,
 		leases:        make(map[int]lease, 10),
 	}
+	handler.ifindex = LookupInterfaceIndexForIP(handler.ip)
 	handler.options = dhcp.Options{
 		dhcp.OptionSubnetMask:       []byte{255, 255, 240, 0},
 		dhcp.OptionRouter:           []byte(handler.ip), // Presuming Server is also your router
@@ -45,38 +69,10 @@ func SetupHandler() *DHCPHandler {
 	return handler
 }
 
-// Example using DHCP with a single network interface
-func ExampleListenAndServe() {
-	log.Fatal(dhcp.ListenAndServe(SetupHandler()))
-}
-
-// Example using DHCP on one interface, with a device with multiple interfaces.
-func ExampleServe() {
-	// The only way to listen to broadcast packets is to listen on all interfaces at the same time.
-	// If you attempt to bind to one interface by specifying an IP, broadcast packets will ignored.
-	// The recommended workaround is to firewall incoming destination port 67 on the undesired interfaces.
-	in, err := net.ListenUDP("udp4", &net.UDPAddr{Port: 67})
-	if err != nil {
-		log.Fatal(err)
+func (h *DHCPHandler) ServeDHCP(ifindex int, p dhcp.Packet, msgType dhcp.MessageType, options dhcp.Options) (d dhcp.Packet) {
+	if ifindex != h.ifindex {
+		return nil
 	}
-	defer in.Close()
-
-	// Packets written to the broadcast listener are sent through the main interface.
-	// On a router this isn't desirable, as the main interface usually connects to the gateway.  Users
-	// of the router are usually on another interface.  To compensate, we create a new connection bound
-	// to the desired interface.  Unfortunately, the source port cannot be set to 67 (required by some
-	// clients) as this is being used by the listener.  The recommended workaround is to use the firewall
-	// to SNAT destination port 68 outgoing packets --to-source :67.
-	out, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(192, 168, 1, 104)})
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer out.Close()
-
-	log.Fatal(dhcp.Serve(in, out, SetupHandler()))
-}
-
-func (h *DHCPHandler) ServeDHCP(p dhcp.Packet, msgType dhcp.MessageType, options dhcp.Options) (d dhcp.Packet) {
 	switch msgType {
 	case dhcp.Discover:
 		free, nic := -1, p.CHAddr().String()
@@ -129,4 +125,8 @@ func (h *DHCPHandler) freeLease() int {
 		}
 	}
 	return -1
+}
+
+func main() {
+	log.Fatal(dhcp.ListenAndServe(SetupHandler()))
 }

--- a/server.go
+++ b/server.go
@@ -1,52 +1,69 @@
 package dhcp4
 
 import (
-	"log"
 	"net"
+
+	"code.google.com/p/go.net/ipv4"
 )
 
 type Handler interface {
-	ServeDHCP(req Packet, msgType MessageType, options Options) Packet
+	ServeDHCP(ifindex int, req Packet, reqtype MessageType, options Options) Packet
 }
 
-type ReaderFromUDP interface {
-	ReadFromUDP(b []byte) (n int, addr *net.UDPAddr, err error)
-}
-
-type WriterToUDP interface {
-	WriteToUDP(b []byte, addr *net.UDPAddr) (n int, err error)
-}
-
-// Serve listens on the listen net.PacketConn, passes DHCP packets to handler and sends
-// the result to the respond PacketConn.
+// Serve takes a net.PacketConn that it uses for both reading and writing DHCP
+// packets. Every packet is passed to the handler, which can process it and
+// optionally return a response packet. A response packet is then written back
+// to the network.
 //
-// Listen and respond are separate to support devices (such as a router)
-// with multiple interfaces, since Go's net library doesn't currently support binding broadcast
-// listeners to a particular interface.  See Examples or https://code.google.com/p/go/issues/detail?id=6935 for more info.
+// To capture limited broadcast packets (sent to 255.255.255.255), you must
+// listen on a socket bound to IP_ADDRANY (0.0.0.0). This means that broadcast
+// packets sent to any interface on the system may be delivered to this socket.
+// The network interface index a DHCP packet was received on is passed to the
+// handler, which is responsible for filtering packets by network interface.
 //
-func Serve(listen ReaderFromUDP, respond WriterToUDP, handler Handler) error {
+// Response packets are sent via the same network interface their corresponding
+// request was received on.
+func Serve(conn net.PacketConn, handler Handler) error {
+	p := ipv4.NewPacketConn(conn)
+	if err := p.SetControlMessage(ipv4.FlagInterface, true); err != nil {
+		return err
+	}
+
 	buffer := make([]byte, 1500)
 	for {
-		n, addr, err := listen.ReadFromUDP(buffer)
+		n, cm, addr, err := p.ReadFrom(buffer)
 		if err != nil {
 			return err
 		}
+
 		if n < 240 { // Packet too small to be DHCP
 			continue
 		}
-		p := Packet(buffer[:n])
-		options := p.ParseOptions()
-		msgType := options[OptionDHCPMessageType]
-		if len(msgType) != 1 {
-			return nil
-		}
-		// TODO consider more packet validity checks
-		if res := handler.ServeDHCP(p, MessageType(msgType[0]), options); res != nil {
-			if addr.IP.Equal(net.IPv4zero) || p.Broadcast() { // If IP not available, broadcast
-				addr.IP = net.IPv4bcast
+
+		src := *addr.(*net.UDPAddr)
+		dst := src
+		req := Packet(buffer[:n])
+		options := req.ParseOptions()
+
+		reqtype := MessageType(0)
+		if t := options[OptionDHCPMessageType]; len(t) != 1 {
+			continue
+		} else {
+			reqtype = MessageType(t[0])
+			if reqtype < Discover || reqtype > Inform {
+				continue
 			}
-			if _, e := respond.WriteToUDP(res, addr); e != nil {
-				log.Println("Write Error:", e.Error())
+		}
+
+		// TODO consider more packet validity checks
+		if res := handler.ServeDHCP(cm.IfIndex, req, reqtype, options); res != nil {
+			if src.IP.Equal(net.IPv4zero) || req.Broadcast() { // If IP not available, broadcast
+				dst.IP = net.IPv4bcast
+			}
+
+			// Inherit control message for interface index
+			if _, err := p.WriteTo(res, cm, &dst); err != nil {
+				return err
 			}
 		}
 	}
@@ -56,10 +73,10 @@ func Serve(listen ReaderFromUDP, respond WriterToUDP, handler Handler) error {
 // and then calls Serve with handler to handle requests
 // on incoming packets.
 func ListenAndServe(handler Handler) error {
-	l, err := net.ListenUDP("udp4", &net.UDPAddr{Port: 67})
+	l, err := net.ListenPacket("udp4", ":67")
 	if err != nil {
 		return err
 	}
 	defer l.Close()
-	return Serve(l, l, handler)
+	return Serve(l, handler)
 }


### PR DESCRIPTION
This allows users to use this code on machines with multiple interfaces without having to configure firewall rules or address translation.

This also takes care of the issue you posted here: https://code.google.com/p/go/issues/detail?id=7106
