### PR TITLE
Don't reuse buffer across requests.

### DIFF
--- a/server.go
+++ b/server.go
@@ -31,8 +31,8 @@ type ServeConn interface {
 // interface that the request was received from.  Writing a custom ServeConn,
 // or using ServeIf() can provide a workaround to this problem.
 func Serve(conn ServeConn, handler Handler) error {
-	buffer := make([]byte, 1500)
 	for {
+		buffer := make([]byte, 1500)
 		n, addr, err := conn.ReadFrom(buffer)
 		if err != nil {
 			return err


### PR DESCRIPTION
I was running into a problem where I was seeing wrong ip and mac addresses in my stored DHCP leases after receiving multiple DHCP requests. It turns out a buffer is allocated [here](https://github.com/krolaw/dhcp4/blob/master/server.go#L34) and reused for each call to `ServeDHCP`, so that when you get the mac and ip byte slices from the `Packet` passed into `ServeDHCP` and store them, they will change when a new request happens (and the buffer is reused). Because everything is backed by the buffer's array.

I believe the solution is to move the buffer allocation into the for loop, so it isn't reused across requests.
