### PR TITLE
Added OptionCode 93 for Client Architecture

### DIFF
--- a/packet.go
+++ b/packet.go
@@ -308,6 +308,8 @@ const (
 	OptionTFTPServerName OptionCode = 66
 	OptionBootFileName   OptionCode = 67
 
+	OptionClientArchitecture OptionCode = 93
+
 	OptionTZPOSIXString    OptionCode = 100
 	OptionTZDatabaseString OptionCode = 101
 


### PR DESCRIPTION
OptionCode 93 is defined in RFC4578 2.1.  It's used to determine which architecture type the client is, if provided by the client.  It can be (is typically) used for determining whether to serve up legacy, 32-bit EFI, or 64-bit EFI (or other) boot images for PXE.  This is a 16-bit int (pair of two bytes), or a list of 16-bit ints (many pairs of two bytes).  Values are defined in RFC4578 2.1.  The most interesting values are 0, 6, 7, and 9, which are Legacy (PC-BIOS), 32-bit EFI, EFI bytecode (universal EFI), and 64-bit EFI.  If it turns out to be a list of ints, it means the device supports each of those returned.  The programmer may want to care about that in their code somehow.  I'm unsure that this package will want to care, there's always room for a helper function attached to this if it fits.