### PR TITLE
Use .To4() on serverId

### DIFF
--- a/packet.go
+++ b/packet.go
@@ -177,7 +177,7 @@ func ReplyPacket(req Packet, mt MessageType, serverId, yIAddr net.IP, leaseDurat
 	p.SetCHAddr(req.CHAddr())
 	p.SetSecs(req.Secs())
 	p.AddOption(OptionDHCPMessageType, []byte{byte(mt)})
-	p.AddOption(OptionServerIdentifier, []byte(serverId))
+	p.AddOption(OptionServerIdentifier, []byte(serverId.To4()))
 	p.AddOption(OptionIPAddressLeaseTime, OptionsLeaseTime(leaseDuration))
 	for _, o := range options {
 		p.AddOption(o.Code, o.Value)


### PR DESCRIPTION
The server id should be four octets, per RFC1533, so call .To4 on it
to ensure we have a v4 address and not a mapped v4 address.