### PR TITLE
Set source address for outgoing to destination address for incoming

### DIFF
--- a/serverif.go
+++ b/serverif.go
@@ -17,6 +17,15 @@ func (s *serveIfConn) ReadFrom(b []byte) (n int, addr net.Addr, err error) {
 	if s.cm != nil && s.cm.IfIndex != s.ifIndex { // Filter all other interfaces
 		n = 0 // Packets < 240 are filtered in Serve().
 	}
+	// Swap the source and destination addresses around, but only
+	// for messages sent to us directly. Else, make the sender be
+	// all zeroes.
+	if net.IPv4bcast.Equal(s.cm.Dst) {
+		s.cm.Src = net.IPv4zero
+	} else {
+		s.cm.Src = s.cm.Dst
+	}
+
 	return
 }
 


### PR DESCRIPTION
We need to swap the source and destionation addresses compared to what
comes in. If we don't do that, we'll try to send with the address of
the destination, something that will error with EINVAL.