### PR TITLE
Name some numeric constants

### DIFF
--- a/packet.go
+++ b/packet.go
@@ -57,10 +57,10 @@ func trimNull(d []byte) []byte {
 	return d
 }
 
-func (p Packet) Cookie() []byte { return p[236:240] }
+func (p Packet) Cookie() []byte { return p[236:MinimalPacketSize] }
 func (p Packet) Options() []byte {
-	if len(p) > 240 {
-		return p[240:]
+	if len(p) > MinimalPacketSize {
+		return p[MinimalPacketSize:]
 	}
 	return nil
 }
@@ -131,8 +131,8 @@ func NewPacket(opCode OpCode) Packet {
 	p := make(Packet, 241)
 	p.SetOpCode(opCode)
 	p.SetHType(1) // Ethernet
-	p.SetCookie([]byte{99, 130, 83, 99})
-	p[240] = byte(End)
+	p.SetCookie(MagicCookie)
+	p[MinimalPacketSize] = byte(End)
 	return p
 }
 
@@ -145,7 +145,7 @@ func (p *Packet) AddOption(o OptionCode, value []byte) {
 
 // Removes all options from packet.
 func (p *Packet) StripOptions() {
-	*p = append((*p)[:240], byte(End))
+	*p = append((*p)[:MinimalPacketSize], byte(End))
 }
 
 // Creates a request packet that a Client would send to a server.
@@ -188,13 +188,22 @@ func ReplyPacket(req Packet, mt MessageType, serverId, yIAddr net.IP, leaseDurat
 
 // PadToMinSize pads a packet so that when sent over UDP, the entire packet,
 // is 300 bytes (BOOTP min), to be compatible with really old devices.
-var padder [272]byte
+var padder [PaddedMinimalPacketSize]byte
 
 func (p *Packet) PadToMinSize() {
-	if n := len(*p); n < 272 {
-		*p = append(*p, padder[:272-n]...)
+	if n := len(*p); n < PaddedMinimalPacketSize {
+		*p = append(*p, padder[:PaddedMinimalPacketSize-n]...)
 	}
 }
+
+// Some constants
+const (
+	MinimalPacketSize       = 240 // Minimal packet size
+	PaddedMinimalPacketSize = 272
+)
+
+// MagicCookie
+var MagicCookie = []byte{99, 130, 83, 99}
 
 // OpCodes
 const (

--- a/packet_test.go
+++ b/packet_test.go
@@ -265,12 +265,11 @@ func TestReplyPacket(t *testing.T) {
 // behavior does not change.
 func newPacket(opCode OpCode) Packet {
 	const ethernetHType = 1
-	var cookie = []byte{99, 130, 83, 99}
 
 	p := make(Packet, 241)
 	p[0] = byte(opCode)
 	p[1] = ethernetHType
-	copy(p[236:240], cookie)
+	copy(p[236:240], MagicCookie)
 	p[240] = byte(End)
 
 	return p

--- a/server.go
+++ b/server.go
@@ -37,7 +37,7 @@ func Serve(conn ServeConn, handler Handler) error {
 		if err != nil {
 			return err
 		}
-		if n < 240 { // Packet too small to be DHCP
+		if n < MinimalPacketSize { // Packet too small to be DHCP
 			continue
 		}
 		req := Packet(buffer[:n])


### PR DESCRIPTION
240 is the minimum size of a DHCP packet. Since it is used at various
places, use a named constant instead. It is also exposed to the
user. The DHCP magic cookie also gets a named variable.