### PR TITLE
Don't set "secs" in replies

### DIFF
--- a/packet.go
+++ b/packet.go
@@ -175,7 +175,6 @@ func ReplyPacket(req Packet, mt MessageType, serverId, yIAddr net.IP, leaseDurat
 	p.SetYIAddr(yIAddr)
 	p.SetGIAddr(req.GIAddr())
 	p.SetCHAddr(req.CHAddr())
-	p.SetSecs(req.Secs())
 	p.AddOption(OptionDHCPMessageType, []byte{byte(mt)})
 	p.AddOption(OptionServerIdentifier, []byte(serverId))
 	p.AddOption(OptionIPAddressLeaseTime, OptionsLeaseTime(leaseDuration))


### PR DESCRIPTION
Per RFC 2131, the "secs" field should stay to 0 for OFFER/ACK/NAK (page
28).