### PR TITLE
Only include "IP Address Lease Time" option when we an IP to offer

### DIFF
--- a/packet.go
+++ b/packet.go
@@ -177,7 +177,9 @@ func ReplyPacket(req Packet, mt MessageType, serverId, yIAddr net.IP, leaseDurat
 	p.SetCHAddr(req.CHAddr())
 	p.AddOption(OptionDHCPMessageType, []byte{byte(mt)})
 	p.AddOption(OptionServerIdentifier, []byte(serverId))
-	p.AddOption(OptionIPAddressLeaseTime, OptionsLeaseTime(leaseDuration))
+	if leaseDuration > 0 {
+		p.AddOption(OptionIPAddressLeaseTime, OptionsLeaseTime(leaseDuration))
+	}
 	for _, o := range options {
 		p.AddOption(o.Code, o.Value)
 	}


### PR DESCRIPTION
RFC 2131 says this option is mandatory in DHCPOFFER, DHCPACK (when in
response to a DHCPREQUEST) and should not appear in DHCPNACK and
DHCPACK (when in response to a DHCPINFORM). Therefore, we just check if
the user provides an IP and only includes this option if we have
one.