### PR TITLE
Add OptionCode 119 for Domain Search Option

### DIFF
--- a/optioncode_string.go
+++ b/optioncode_string.go
@@ -10,8 +10,9 @@ const (
 	_OptionCode_name_2 = "OptionRelayAgentInformation"
 	_OptionCode_name_3 = "OptionClientArchitecture"
 	_OptionCode_name_4 = "OptionTZPOSIXStringOptionTZDatabaseString"
-	_OptionCode_name_5 = "OptionClasslessRouteFormat"
-	_OptionCode_name_6 = "End"
+	_OptionCode_name_5 = "OptionDomainSearch"
+	_OptionCode_name_6 = "OptionClasslessRouteFormat"
+	_OptionCode_name_7 = "End"
 )
 
 var (
@@ -20,8 +21,9 @@ var (
 	_OptionCode_index_2 = [...]uint8{0, 27}
 	_OptionCode_index_3 = [...]uint8{0, 24}
 	_OptionCode_index_4 = [...]uint8{0, 19, 41}
-	_OptionCode_index_5 = [...]uint8{0, 26}
-	_OptionCode_index_6 = [...]uint8{0, 3}
+	_OptionCode_index_5 = [...]uint8{0, 18}
+	_OptionCode_index_6 = [...]uint8{0, 26}
+	_OptionCode_index_7 = [...]uint8{0, 3}
 )
 
 func (i OptionCode) String() string {
@@ -38,10 +40,12 @@ func (i OptionCode) String() string {
 	case 100 <= i && i <= 101:
 		i -= 100
 		return _OptionCode_name_4[_OptionCode_index_4[i]:_OptionCode_index_4[i+1]]
-	case i == 121:
+	case i == 119:
 		return _OptionCode_name_5
-	case i == 255:
+	case i == 121:
 		return _OptionCode_name_6
+	case i == 255:
+		return _OptionCode_name_7
 	default:
 		return fmt.Sprintf("OptionCode(%d)", i)
 	}

--- a/packet.go
+++ b/packet.go
@@ -320,6 +320,8 @@ const (
 	OptionTZPOSIXString    OptionCode = 100
 	OptionTZDatabaseString OptionCode = 101
 
+	OptionDomainSearch OptionCode = 119
+
 	OptionClasslessRouteFormat OptionCode = 121
 )
 


### PR DESCRIPTION
OptionCode `119` is defined in [RFC3397](https://tools.ietf.org/search/rfc3397) as `Domain Search Option`.
Added the name of `OptionCode(119)` and executed `go generate`.