### PR TITLE
Allocate a new buffer per request packet

### DIFF
--- a/server.go
+++ b/server.go
@@ -37,8 +37,10 @@ type ServeConn interface {
 // interface that the request was received from.  Writing a custom ServeConn,
 // or using ServeIf() can provide a workaround to this problem.
 func Serve(conn ServeConn, handler Handler) error {
-	buffer := make([]byte, 1500)
 	for {
+		// Use a unique buffer per packet to ensure packet references
+		// stay consistent when passed to ServeDHCP
+		buffer := make([]byte, 1500)
 		n, addr, err := conn.ReadFrom(buffer)
 		if err != nil {
 			return err


### PR DESCRIPTION
Request Packet types are passed directly to ServeDHCP().  If a
ServeDHCP() implementation saves a reference to the Packet or return
values to Packet.*Addr(), which are all just slices of the same Packet
buffer, they become stale as soon as the next request Packet is read
over the top of the same buffer

By allocating a new request Packet every time, the references will
remain consistent forever at the cost of some garbage collection.