### PR TITLE
Forcing a copy of Packet in Serve

### DIFF
--- a/server.go
+++ b/server.go
@@ -46,8 +46,9 @@ func Serve(conn ServeConn, handler Handler) error {
 		if n < 240 { // Packet too small to be DHCP
 			continue
 		}
-		req := Packet(buffer[:n])
-		if req.HLen() > 16 { // Invalid size
+
+		req := append(Packet(nil), Packet(buffer[:n])...) // Force a copy
+		if req.HLen() > 16 {                              // Invalid size
 			continue
 		}
 		options := req.ParseOptions()


### PR DESCRIPTION
Serve is reusing the buffer in every call to ServeDHCP. As a result any value that is stored during ServeDHCP risk having the underlying buffer overwritten at any time, causing a lot of hard to find bugs downstream. Changed code to force a copy of the underlying buffer.